### PR TITLE
Fix SyntaxWarning in recovery.py

### DIFF
--- a/recovery.py
+++ b/recovery.py
@@ -116,7 +116,7 @@ for root, dirs, files in os.walk(source, topdown=False):
             shutil.copy2(sourcePath, destinationFile)
 
         fileCounter += 1
-        if((fileCounter % onePercentFiles) is 0):
+        if((fileCounter % onePercentFiles) == 0):
             log(str(fileCounter) + " / " + totalAmountToCopy + " processed.")
 
 log("start special file treatment")


### PR DESCRIPTION
Fixes:
```
recovery.py:119: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if((fileCounter % onePercentFiles) is 0):
  ```