### PR TITLE
fix division by zero if less than 100 files are copied

### DIFF
--- a/recovery.py
+++ b/recovery.py
@@ -90,7 +90,10 @@ while ((destination is None) or (not os.path.exists(destination))):
     destination = input('Enter a valid destination directory\n')
 
 fileNumber = getNumberOfFilesInFolderRecursively(source)
-onePercentFiles = int(fileNumber/100)
+if fileNumber > 100:
+    onePercentFiles = int(fileNumber/100)
+else:
+    onePercentFiles = fileNumber
 totalAmountToCopy = str(fileNumber)
 print("Files to copy: " + totalAmountToCopy)
 


### PR DESCRIPTION
Hi Lukas,
needed to "play around" with your toll in the last days. While testing I found a bug.

If less then 100 files are processed the onePercentFiles becomes zero subsequently leading to a divide by zero error.

This should fix this.

Best regards


Tobias